### PR TITLE
fixed error shown in editor due to missing font

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -28,7 +28,7 @@ function philomina_main_dependancies() {
 
 add_action( 'admin_init', 'philomina_editor_styles' );
 function philomina_editor_styles() {
-	$philomina_font_url = str_replace(',', '%2C', '//fonts.googleapis.com/css?Lato:400,300,300italic,400italic,700,700italic' );
+	$philomina_font_url = str_replace(',', '%2C', '//fonts.googleapis.com/css?family=Lato:400,300,300italic,400italic,700,700italic' );
     $philomina_stylesheet = get_template_directory_uri() . '/editor-style.css';
     add_editor_style( array($philomina_font_url, $philomina_stylesheet));
 }


### PR DESCRIPTION
a minor error in the google font link showed up in the editor as an error popup (failed to load css://fonts.google....).